### PR TITLE
Update to react-native-telephony to include earfcn and phoneinfo

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,18 +5,18 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 24
+    buildToolsVersion '25.0.3'
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion 24
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
     }
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.facebook.react:react-native:+'
     // From node_modules
 }

--- a/android/app/src/main/java/com/telephony/TelephonyModule.java
+++ b/android/app/src/main/java/com/telephony/TelephonyModule.java
@@ -114,7 +114,7 @@ public class TelephonyModule extends ReactContextBaseJavaModule
         successCallback.invoke(telephonyManager.isNetworkRoaming());
     }
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @TargetApi(Build.VERSION_CODES.N)
     @ReactMethod
     public void getCellInfo(Callback successCallback) {
 
@@ -179,7 +179,7 @@ public class TelephonyModule extends ReactContextBaseJavaModule
                 mapCellIdentity.putInt("tac", cellIdentity.getTac());
                 mapCellIdentity.putInt("mcc", cellIdentity.getMcc());
                 mapCellIdentity.putInt("mnc", cellIdentity.getMnc());
-                mapCellIdentity.putInt("psc", cellIdentity.getPci());
+                mapCellIdentity.putInt("pci", cellIdentity.getPci());
                 mapCellIdentity.putInt("earfcn", cellIdentity.getEarfcn());
 
                 String cellIdHex = decToHex(cellIdentity.getCi());

--- a/android/app/src/main/java/com/telephony/TelephonyModule.java
+++ b/android/app/src/main/java/com/telephony/TelephonyModule.java
@@ -105,6 +105,8 @@ public class TelephonyModule extends ReactContextBaseJavaModule
     public void stopListener() {
         telephonyManager.listen(telephonyPhoneStateListener,
                 PhoneStateListener.LISTEN_NONE);
+        telephonyManager = null;
+        telephonyPhoneStateListener = null;
     }
 
     @ReactMethod
@@ -165,14 +167,26 @@ public class TelephonyModule extends ReactContextBaseJavaModule
                 mapCellSignalStrength.putInt("dBm", cellSignalStrengthWcdma.getDbm());
                 mapCellSignalStrength.putInt("level", cellSignalStrengthWcdma.getLevel());
             } else if (info instanceof CellInfoLte) {
+                if(info.isRegistered()) {
+                    mapCellIdentity.putBoolean("servingCellFlag", info.isRegistered());
+                } else {
+                    mapCellIdentity.putBoolean("servingCellFlag", info.isRegistered());
+                }
                 CellIdentityLte cellIdentity = ((CellInfoLte) info).getCellIdentity();
                 map.putString("connectionType", "LTE");
 
                 mapCellIdentity.putInt("cid", cellIdentity.getCi());
-                mapCellIdentity.putInt("lac", cellIdentity.getTac());
+                mapCellIdentity.putInt("tac", cellIdentity.getTac());
                 mapCellIdentity.putInt("mcc", cellIdentity.getMcc());
                 mapCellIdentity.putInt("mnc", cellIdentity.getMnc());
                 mapCellIdentity.putInt("psc", cellIdentity.getPci());
+                mapCellIdentity.putInt("earfcn", cellIdentity.getEarfcn());
+
+                String cellIdHex = decToHex(cellIdentity.getCi());
+                String eNodeBHex = cellIdHex.substring(0, cellIdHex.length() - 2);
+                mapCellIdentity.putInt("eNodeB", hexToDec(eNodeBHex));
+                String localCellIdHex = cellIdHex.substring(cellIdHex.length() - 2, cellIdHex.length());
+                mapCellIdentity.putInt("localCellId", hexToDec(localCellIdHex));
 
                 CellSignalStrengthLte cellSignalStrengthLte = ((CellInfoLte) info).getCellSignalStrength();
 
@@ -213,6 +227,19 @@ public class TelephonyModule extends ReactContextBaseJavaModule
         }
 
         successCallback.invoke(mapArray);
+    }
+
+    @ReactMethod
+    public void getPhoneInfo(Callback successCallBack) {
+        WritableMap mapPhoneInfo = Arguments.createMap();
+
+        mapPhoneInfo.putString("imsi", telephonyManager.getSubscriberId().toString());
+        mapPhoneInfo.putString("imei", telephonyManager.getDeviceId());
+        mapPhoneInfo.putString("mdn", telephonyManager.getLine1Number());
+        mapPhoneInfo.putString("model", Build.MANUFACTURER
+            + " " + Build.MODEL + " " + Build.VERSION.RELEASE
+            + " " + Build.VERSION_CODES.class.getFields()[Build.VERSION.SDK_INT].getName());
+        successCallBack.invoke(mapPhoneInfo);
     }
 
     @ReactMethod
@@ -465,5 +492,13 @@ public class TelephonyModule extends ReactContextBaseJavaModule
     @Override
     public void onHostDestroy() {
         stopListener();
+    }
+
+    public String decToHex(int dec) {
+        return String.format("%x", dec);
+    }
+
+    public int hexToDec(String hex) {
+        return Integer.parseInt(hex, 16);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,34 +1,38 @@
 {
 	"name": "react-native-telephony",
-  "version": "1.3.1",
-  "description": "",
-  "main": "index.js",
+	"version": "1.3.1",
+	"description": "",
+	"main": "index.js",
 	"scripts": {
 		"test": "jest"
 	},
 	"author": "Rafael Lincoln <rafaellincolnpereira@gmail.com>",
 	"repository": {
-    "type": "git",
-    "url": "https://github.com/rafaellincoln/react-native-telephony"
+		"type": "git",
+		"url": "https://github.com/rafaellincoln/react-native-telephony"
 	},
 	"keywords": [
-    "react",
-    "react-native",
-    "telephony",
-    "listen",
-    "call",
-    "android",
-    "cell",
-    "info"
-  ],
+		"react",
+		"react-native",
+		"telephony",
+		"listen",
+		"call",
+		"android",
+		"cell",
+		"info"
+	],
 	"license": "MIT",
 	"devDependencies": {
 		"babel-jest": "20.0.3",
 		"babel-preset-react-native": "2.0.0",
-		"jest": "20.0.4",
-		"react-test-renderer": "16.0.0-alpha.12"
+		"jest": "^20.0.4",
+		"react-test-renderer": "^16.0.0-rc.2"
 	},
 	"jest": {
 		"preset": "react-native"
+	},
+	"dependencies": {
+		"react": "^16.0.0-rc.2",
+		"react-native": "^0.48.2"
 	}
 }


### PR DESCRIPTION
Hello,

Made changes to the android module to support:

1. Getting EARFCN
2. Getting local Cell ID
3. Getting eNodeB ID
4. Getting IMEI/IMSI/MDN/Phone model
5. Corrected nomenclature in the LTE block from lac to tac

The new features will require API24.  